### PR TITLE
Merge feature-tabs-make-enclosing-shortcode

### DIFF
--- a/inc/cl-shortcodes.php
+++ b/inc/cl-shortcodes.php
@@ -553,7 +553,6 @@ function uri_cl_shortcode_tab( $atts, $content = null ) {
 		shortcode_atts(
 		array(
 			'title' => '',
-			'body' => '',
 			'id' => '',
 			'class' => '',
 			'css' => '',

--- a/inc/templates/cl-template-tab.php
+++ b/inc/templates/cl-template-tab.php
@@ -16,8 +16,6 @@ if ( ! empty( $title ) ) {
 	$output .= '<h1>' . $title . '</h1>';
 }
 
-if ( ! empty( $body ) ) {
-	$output .= '<p>' . $body . '</p>';
-}
+$output .= do_shortcode( $content );
 
 $output .= '</section>';


### PR DESCRIPTION
## Changes

* Makes `[cl-tab]` an enclosing shortcode
* Removes the `[cl-tab]` `body` attribute

## Notes

Fixes #61.

**WARNING:** This will break any tabs out there.  Content in `body` attributes should be moved to between opening and closing shortcode tags, e.g.:

`[cl-tab body="foo"]` --> `[cl-tab]foo[/cl-tab]`