### PR TITLE
Release 3.4.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,6 @@
 # gulp files
 gulpfile.js export-ignore
 package.json export-ignore
+package-lock.json export-ignore
 # src files 
 src export-ignore

--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 The Component Library exists in order to standardize the look and feel of web elements, and make it fast and simple to build webpages that look great and stay on-brand.
 
-## What's new in 3.3.0
+## What's new in 3.4.0
 
-CL 3.3.0 is a minor release focused on hero and video component functionality.
+CL 3.4.0 is a minor release focusing on [Display Posts Shortcode](https://github.com/billerickson/display-posts-shortcode) plugin extensions.
 
-* Adds scroll functionality to super hero prompters (smooth scrolling behavior requires a [polyfill](http://iamdustan.com/smoothscroll/), available starting in [URI Modern v1.2.1](https://github.com/uriweb/uri-modern/releases/tag/1.2.1))
-* Updates link text color to comply with WCAG standards
-* Uses the YouTube poster image by default for videos and video heroes
-* Uses the `vid` value for video and hero component ids (setting an id manually is no longer available via the Visual Editor)
-* Updates development tools
+* Adds support for displaying posts as components using Display Posts:
+	- Display lists of posts as either cards, story cards, heroes, or panels
+	- Customize components in the Display Posts shortcode by using the applicable component shortcode attribute(s) and the prefix `cl-`
 
-For complete details, see the [commit history](https://github.com/uriweb/uri-component-library/pull/123/commits) and the [issue tracker](https://github.com/uriweb/uri-component-library/issues). 
+For complete details, see the [commit history](https://github.com/uriweb/uri-component-library/pull/126/commits) and the [issue tracker](https://github.com/uriweb/uri-component-library/issues). 
 
 ## Plugin Details
 

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Contributors: Brandon Fuller, John Pennypacker
 Tags: plugins  
 Requires at least: 4.0  
 Tested up to: 4.9  
-Stable tag: 3.3.0  
+Stable tag: 3.4.0  

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CL 3.4.0 is a minor release focusing on [Display Posts Shortcode](https://github
 * Adds support for displaying posts as components using Display Posts:
 	- Display lists of posts as either cards, story cards, heroes, or panels
 	- Customize components in the Display Posts shortcode by using the applicable component shortcode attribute(s) and the prefix `cl-`
+* Other minor bug fixes
 
 For complete details, see the [commit history](https://github.com/uriweb/uri-component-library/pull/126/commits) and the [issue tracker](https://github.com/uriweb/uri-component-library/issues). 
 

--- a/css/cl.built.css
+++ b/css/cl.built.css
@@ -3,7 +3,7 @@
  * 
  * --styles--
  * 
- * @version v3.3.0
+ * @version v3.4.0
  * @author Brandon Fuller <bjcfuller@uri.edu>
  * @author John Pennypacker <jpennypacker@uri.edu>
  * @license GPL-3.0

--- a/inc/cl-display-posts.php
+++ b/inc/cl-display-posts.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * COMPONENT LIBRARY DISPLAY POSTS EXTENSIONS
+ *
+ * @package uri-component-library
+ */
+
+/**
+ * Components
+ *
+ * @see https://www.billerickson.net/template-parts-with-display-posts-shortcode
+ *
+ * @param str $output Current output of post.
+ * @param arr $original_atts Original attributes passed to shortcode.
+ * @return str $output
+ */
+function uri_cl_display_posts_component( $output, $original_atts ) {
+
+	if ( empty( $original_atts['component'] ) ) {
+		return $output;
+	}
+
+	ob_start();
+	$template = null;
+
+	if ( ! empty( $original_atts['component'] ) ) {
+		$template = URI_CL_DIR_PATH . 'inc/display-posts/cl-display-posts-' . $original_atts['component'] . '.php';
+	}
+
+	if ( is_file( $template ) ) {
+		include $template;
+	}
+
+	$html = ob_get_clean();
+
+	if ( ! empty( $html ) ) {
+		$output = $html;
+	}
+
+	return $output;
+
+}
+add_action( 'display_posts_shortcode_output', 'uri_cl_display_posts_component', 10, 2 );

--- a/inc/cl-display-posts.php
+++ b/inc/cl-display-posts.php
@@ -20,6 +20,14 @@ function uri_cl_display_posts_component( $output, $original_atts ) {
 		return $output;
 	}
 
+	$cl_atts = '';
+
+	foreach ( $original_atts as $k => $v ) {
+		if ( preg_match( '/^cl-/', $k ) ) {
+			$cl_atts .= str_replace( 'cl-', '', $k ) . '="' . $v . '" ';
+		}
+	};
+
 	ob_start();
 	$template = null;
 

--- a/inc/display-posts/cl-display-posts-card.php
+++ b/inc/display-posts/cl-display-posts-card.php
@@ -5,4 +5,4 @@
  * @package uri-component-library
  */
 
-print do_shortcode( '[cl-card title="' . get_the_title() . '" body="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More"]' );
+print do_shortcode( '[cl-card title="' . get_the_title() . '" body="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More" ' . $cl_atts . ']' );

--- a/inc/display-posts/cl-display-posts-card.php
+++ b/inc/display-posts/cl-display-posts-card.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * The template for displaying a post as a card
+ *
+ * @package uri-component-library
+ */
+
+print do_shortcode( '[cl-card title="' . get_the_title() . '" body="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More"]' );

--- a/inc/display-posts/cl-display-posts-hero.php
+++ b/inc/display-posts/cl-display-posts-hero.php
@@ -5,4 +5,4 @@
  * @package uri-component-library
  */
 
-print do_shortcode( '[cl-hero headline="' . get_the_title() . '" subhead="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More"]' );
+print do_shortcode( '[cl-hero headline="' . get_the_title() . '" subhead="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More" ' . $cl_atts . ']' );

--- a/inc/display-posts/cl-display-posts-hero.php
+++ b/inc/display-posts/cl-display-posts-hero.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * The template for displaying a post as a hero
+ *
+ * @package uri-component-library
+ */
+
+print do_shortcode( '[cl-hero headline="' . get_the_title() . '" subhead="' . get_the_excerpt() . '" link="' . get_the_permalink() . '" img="' . get_the_post_thumbnail_url() . '" button="Read More"]' );

--- a/inc/display-posts/cl-display-posts-panel.php
+++ b/inc/display-posts/cl-display-posts-panel.php
@@ -5,7 +5,7 @@
  * @package uri-component-library
  */
 
-$sc = '[cl-panel title="' . get_the_title() . '" img="' . get_the_post_thumbnail_url() . '"]';
+$sc = '[cl-panel title="' . get_the_title() . '" img="' . get_the_post_thumbnail_url() . '" ' . $cl_atts . ']';
 $sc .= get_the_excerpt();
 $sc .= '<p>[cl-button link="' . get_the_permalink() . '" text="Read More"]</p>';
 $sc .= '[/cl-panel]';

--- a/inc/display-posts/cl-display-posts-panel.php
+++ b/inc/display-posts/cl-display-posts-panel.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * The template for displaying a post as a hero
+ *
+ * @package uri-component-library
+ */
+
+$sc = '[cl-panel title="' . get_the_title() . '" img="' . get_the_post_thumbnail_url() . '"]';
+$sc .= get_the_excerpt();
+$sc .= '<p>[cl-button link="' . get_the_permalink() . '" text="Read More"]</p>';
+$sc .= '[/cl-panel]';
+
+print do_shortcode( $sc );

--- a/inc/display-posts/cl-display-posts-scard.php
+++ b/inc/display-posts/cl-display-posts-scard.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * The template for displaying a post as a story card
+ *
+ * @package uri-component-library
+ */
+
+print do_shortcode( '[cl-scard post="' . get_the_ID() . '"]' );

--- a/inc/display-posts/cl-display-posts-scard.php
+++ b/inc/display-posts/cl-display-posts-scard.php
@@ -5,4 +5,4 @@
  * @package uri-component-library
  */
 
-print do_shortcode( '[cl-scard post="' . get_the_ID() . '"]' );
+print do_shortcode( '[cl-scard post="' . get_the_ID() . '" ' . $cl_atts . ']' );

--- a/js/cl.built.js
+++ b/js/cl.built.js
@@ -3,7 +3,7 @@
  * 
  * --scripts--
  * 
- * @version v3.3.0
+ * @version v3.4.0
  * @author Brandon Fuller <bjcfuller@uri.edu>
  * @author John Pennypacker <jpennypacker@uri.edu>
  * @license GPL-3.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uri-component-library",
   "description": "URI Component Library",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "homepage": "https://www.uri.edu",
   "repository": "https://github.com/uriweb/uri-component-library",
   "docs": "https://www.uri.edu/styleguide",

--- a/src/js/heroes.js
+++ b/src/js/heroes.js
@@ -95,7 +95,7 @@ var CLResizeSuperheroes;
 
 	function superhero() {
 
-		var H = [], els, n, i, id, prompt, after;
+		var H = [], els, n, i, prompt, after;
 
 		els = document.querySelectorAll( '.cl-hero.super' );
 		n = els.length;

--- a/uri-component-library.php
+++ b/uri-component-library.php
@@ -3,7 +3,7 @@
  * Plugin Name: URI Component Library
  * Plugin URI: http://www.uri.edu
  * Description: Component Library
- * Version: 3.3.0
+ * Version: 3.4.0
  * Author: URI Web Communications
  * Author URI: https://today.uri.edu/
  *

--- a/uri-component-library.php
+++ b/uri-component-library.php
@@ -43,6 +43,9 @@ add_action( 'wp_enqueue_scripts', 'uri_cl_enqueues' );
 // Include shortcodes
 include( URI_CL_DIR_PATH . 'inc/cl-shortcodes.php' );
 
+// Include display posts extensions
+include( URI_CL_DIR_PATH . 'inc/cl-display-posts.php' );
+
 // Include WYSIWYG buttons on all themes except URI Responsive
 if ( 'responz-child' != wp_get_theme()->get_stylesheet() ) {
 	include( URI_CL_DIR_PATH . 'inc/cl-wysiwyg.php' );


### PR DESCRIPTION
## What's new in 3.4.0

CL 3.4.0 is a minor release focusing on [Display Posts Shortcode](https://github.com/billerickson/display-posts-shortcode) plugin extensions.

* Adds support for displaying posts as components using Display Posts:
	- Display lists of posts as either cards, story cards, heroes, or panels
	- Customize components in the Display Posts shortcode by using the applicable component shortcode attribute(s) and the prefix `cl-`
* Other minor bug fixes