### PR TITLE
disables the publish button, and the Visual/Text toggle while compone…

### DIFF
--- a/js/wysiwyg/cl-wysiwyg-helpers.js
+++ b/js/wysiwyg/cl-wysiwyg-helpers.js
@@ -195,7 +195,7 @@ class URIWYSIWYG {
 					}
 
 				},
-				complete: function( data, textStatus, jqXHR ) {
+				complete: function() {
 					URIWYSIWYGoutStandingRequests--;
 					if ( URIWYSIWYGoutStandingRequests < 1 ) {
 						jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', null );

--- a/js/wysiwyg/cl-wysiwyg-helpers.js
+++ b/js/wysiwyg/cl-wysiwyg-helpers.js
@@ -4,9 +4,18 @@
  * @package uri-component-library
  */
 
+var URIWYSIWYGoutStandingRequests = 0;
+var URIWYSIWYGpublishButtonValue;
+
+jQuery(document).ready(function() {
+	URIWYSIWYGpublishButtonValue = jQuery('#publish').val();
+});
+
 // jshint esversion: 6
 // jscs:disable requireVarDeclFirst
+
 class URIWYSIWYG {
+	
 
 	/**
 	 * Escapes quotes on every element in an array (if element is a string)
@@ -136,6 +145,11 @@ class URIWYSIWYG {
 					console.log( textStatus );
 					console.log( errorThrown );
 				},
+				beforeSend: function () {
+					URIWYSIWYGoutStandingRequests++;
+					jQuery('#publish, #content-tmce, #content-html').attr('disabled', true)
+					jQuery('#publish').val('loading');
+				},
 				success: function( data, textStatus, jqXHR ) {
 
 					var placeHolder, d;
@@ -180,8 +194,12 @@ class URIWYSIWYG {
 					}
 
 				},
-				done: function( data, textStatus, jqXHR ) {
-					console.log( 'Done.' );
+				complete: function( data, textStatus, jqXHR ) {
+					URIWYSIWYGoutStandingRequests--;
+					if( URIWYSIWYGoutStandingRequests < 1 ) {
+						jQuery('#publish, #content-tmce, #content-html').attr('disabled', null)
+						jQuery('#publish').val( URIWYSIWYGpublishButtonValue );
+					}
 				}
 		}
 			);

--- a/js/wysiwyg/cl-wysiwyg-helpers.js
+++ b/js/wysiwyg/cl-wysiwyg-helpers.js
@@ -4,6 +4,9 @@
  * @package uri-component-library
  */
 
+ // jshint esversion: 6
+ // jscs:disable requireVarDeclFirst
+
 var URIWYSIWYGoutStandingRequests = 0;
 var URIWYSIWYGpublishButtonValue;
 
@@ -13,11 +16,7 @@ jQuery( document ).ready(
 	}
 	);
 
-// jshint esversion: 6
-// jscs:disable requireVarDeclFirst
-
 class URIWYSIWYG {
-
 
 	/**
 	 * Escapes quotes on every element in an array (if element is a string)
@@ -147,9 +146,9 @@ class URIWYSIWYG {
 					console.log( textStatus );
 					console.log( errorThrown );
 				},
-				beforeSend: function () {
+				beforeSend: function() {
 					URIWYSIWYGoutStandingRequests++;
-					jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', true )
+					jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', true );
 					jQuery( '#publish' ).val( 'loading' );
 				},
 				success: function( data, textStatus, jqXHR ) {
@@ -199,7 +198,7 @@ class URIWYSIWYG {
 				complete: function( data, textStatus, jqXHR ) {
 					URIWYSIWYGoutStandingRequests--;
 					if ( URIWYSIWYGoutStandingRequests < 1 ) {
-						jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', null )
+						jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', null );
 						jQuery( '#publish' ).val( URIWYSIWYGpublishButtonValue );
 					}
 				}

--- a/js/wysiwyg/cl-wysiwyg-helpers.js
+++ b/js/wysiwyg/cl-wysiwyg-helpers.js
@@ -7,15 +7,17 @@
 var URIWYSIWYGoutStandingRequests = 0;
 var URIWYSIWYGpublishButtonValue;
 
-jQuery(document).ready(function() {
-	URIWYSIWYGpublishButtonValue = jQuery('#publish').val();
-});
+jQuery( document ).ready(
+	function() {
+		URIWYSIWYGpublishButtonValue = jQuery( '#publish' ).val();
+	}
+	);
 
 // jshint esversion: 6
 // jscs:disable requireVarDeclFirst
 
 class URIWYSIWYG {
-	
+
 
 	/**
 	 * Escapes quotes on every element in an array (if element is a string)
@@ -147,8 +149,8 @@ class URIWYSIWYG {
 				},
 				beforeSend: function () {
 					URIWYSIWYGoutStandingRequests++;
-					jQuery('#publish, #content-tmce, #content-html').attr('disabled', true)
-					jQuery('#publish').val('loading');
+					jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', true )
+					jQuery( '#publish' ).val( 'loading' );
 				},
 				success: function( data, textStatus, jqXHR ) {
 
@@ -196,9 +198,9 @@ class URIWYSIWYG {
 				},
 				complete: function( data, textStatus, jqXHR ) {
 					URIWYSIWYGoutStandingRequests--;
-					if( URIWYSIWYGoutStandingRequests < 1 ) {
-						jQuery('#publish, #content-tmce, #content-html').attr('disabled', null)
-						jQuery('#publish').val( URIWYSIWYGpublishButtonValue );
+					if ( URIWYSIWYGoutStandingRequests < 1 ) {
+						jQuery( '#publish, #content-tmce, #content-html' ).attr( 'disabled', null )
+						jQuery( '#publish' ).val( URIWYSIWYGpublishButtonValue );
 					}
 				}
 		}


### PR DESCRIPTION
Disables the publish button, and the Visual/Text toggle while components are loading HTML previews.

There's a bug where an editor might switch out of visual mode or publish a post while the CL is loading a preview.  In this circumstance, the editor dutifully saves the current content, which is likely to be "Loading..."  This update prevents the editor from performing those actions until all of the component library previews have loaded.