### PR TITLE
Merge feat-extend-display-posts-notice into develop

### DIFF
--- a/inc/display-posts/cl-display-posts-notice.php
+++ b/inc/display-posts/cl-display-posts-notice.php
@@ -7,7 +7,11 @@
 
 $sc = '[cl-notice title="' . _uri_cl_escape_brackets( get_the_title() ) . '" ' . $cl_atts . ']';
 $sc .= _uri_cl_escape_brackets( get_the_excerpt() );
-$sc .= '<p><a href="' . get_the_permalink() . '">Read more</a></p>';
+
+if ( "true" == $original_atts['include_link'] ) {
+    $sc .= '<p><a class="cl-notice-display-post-link" href="' . get_the_permalink() . '">Read more</a></p>';
+}
+
 $sc .= '[/cl-notice]';
 
 print do_shortcode( $sc );

--- a/inc/display-posts/cl-display-posts-notice.php
+++ b/inc/display-posts/cl-display-posts-notice.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * The template for displaying a post as a notice
+ *
+ * @package uri-component-library
+ */
+
+$sc = '[cl-notice title="' . _uri_cl_escape_brackets( get_the_title() ) . '" ' . $cl_atts . ']';
+$sc .= _uri_cl_escape_brackets( get_the_excerpt() );
+$sc .= '<p><a href="' . get_the_permalink() . '">Read more</a></p>';
+$sc .= '[/cl-notice]';
+
+print do_shortcode( $sc );

--- a/inc/display-posts/cl-display-posts-panel.php
+++ b/inc/display-posts/cl-display-posts-panel.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying a post as a hero
+ * The template for displaying a post as a panel
  *
  * @package uri-component-library
  */


### PR DESCRIPTION
Adds notices to the list of components that can be used with Display Posts