### PR TITLE
Release 5.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ __Contributors:__ [bjcfuller](https://github.com/bjcfuller), [johnpennypacker](h
 __Tags:__ plugins, shortcodes  
 __Requires at least:__ 5.8  
 __Tested up to:__ 6.9.4  
-__Stable tag:__ 5.3.0  
+__Stable tag:__ 5.3.1 
 __License:__ GPL-3.0  
 __Licence URI:__ https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ The Component Library standardizes the look and feel of web elements, and makes 
 
 See [this documentation](https://www.uri.edu/wordpress/components/) to learn about components and how to use them.
 
+## What's new in 5.3.1
+
+CL 5.3.1 is a patch release that continues to enhance the accessibility of components. 
+
+* Removes slideshows in favor of using the native Wordpress Gallery block
+* Edits the accessible name of social media icons on the Share component
+* Adjusts the X icon on the Share component
+* Adds columns as an allowed block within the Breakout component
+
 ## What's new in 5.3.0 
 
 CL 5.3.0 is a minor release that focuses on functionality and accessibility improvements. 
@@ -48,7 +57,7 @@ For help with using components, see [documentation](https://www.uri.edu/wordpres
 __Contributors:__ [bjcfuller](https://github.com/bjcfuller), [johnpennypacker](https://github.com/johnpennypacker), [alexandragauss](https://github.com/alexandragauss)  
 __Tags:__ plugins, shortcodes  
 __Requires at least:__ 5.8  
-__Tested up to:__ 6.9.1  
+__Tested up to:__ 6.9.4  
 __Stable tag:__ 5.3.0  
 __License:__ GPL-3.0  
 __Licence URI:__ https://www.gnu.org/licenses/gpl-3.0.html

--- a/css/cl.built.css
+++ b/css/cl.built.css
@@ -3,7 +3,7 @@
  * 
  * --styles--
  * 
- * @version v5.3.0
+ * @version v5.3.1
  * @author Brandon Fuller <bjcfuller@uri.edu>
  * @author John Pennypacker <jpennypacker@uri.edu>
  * @license GPL-3.0

--- a/js/cl.built.js
+++ b/js/cl.built.js
@@ -3,7 +3,7 @@
  * 
  * --scripts--
  * 
- * @version v5.3.0
+ * @version v5.3.1
  * @author Brandon Fuller <bjcfuller@uri.edu>
  * @author John Pennypacker <jpennypacker@uri.edu>
  * @license GPL-3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uri-component-library",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uri-component-library",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/core": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uri-component-library",
   "description": "URI Component Library",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "homepage": "https://www.uri.edu",
   "repository": "https://github.com/uriweb/uri-component-library",
   "docs": "https://www.uri.edu/wordpress",

--- a/uri-component-library.php
+++ b/uri-component-library.php
@@ -3,7 +3,7 @@
  * Plugin Name: URI Component Library
  * Plugin URI: http://github.com/uriweb/uri-component-library
  * Description: Standardizes the look and feel of web elements, and makes it fast and simple to build webpages that look great and stay on-brand.
- * Version: 5.3.0
+ * Version: 5.3.1
  * Author: URI Web Communications
  * Author URI: https://www.uri.edu/wordpress
  *


### PR DESCRIPTION
## Changes

* Removes slideshows in favor of using the native Wordpress Gallery block
* Edits the accessible name of social media icons on the Share component
* Adjusts the X icon on the Share component
* Adds columns as an allowed block within the Breakout component